### PR TITLE
Fixed path issue related to fontloader

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@
  */
 
 import Blits from '@lightningjs/blits'
-import fontLoader from './fontloader.js?importChunkUrl'
+import fontLoader from './fontLoader.js?importChunkUrl'
 
 import App from './App.js'
 


### PR DESCRIPTION
This PR fixes the issue of fontloader error given below : 

**OS: Linux**

> 
> Error:   Failed to scan for dependencies from entries:
>   /home/sandeepv/Desktop/TestingApps/blits-example-app/index.html
>   ✘ [ERROR] Could not resolve source file for ./fontloader.js [plugin vite:dep-scan]