### PR TITLE
Fixes path resolution for subfolder deployment

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,6 @@
     </head>
     <body>
         <div id="app"></div>
-        <script type="module" src="/src/index.js"></script>
+        <script type="module" src="src/index.js"></script>
     </body>
 </html>

--- a/src/components/Letter.js
+++ b/src/components/Letter.js
@@ -30,7 +30,7 @@ export default Blits.Component('Letter', {
   props: ['w', 'letter', 'direction', 'delay'],
   computed: {
     image() {
-      return `${window.location.protocol}//${window.location.host}/assets/${this.letter}.png`
+      return `assets/${this.letter}.png`
     },
   },
   state() {

--- a/src/index.js
+++ b/src/index.js
@@ -35,21 +35,21 @@ Blits.Launch(App, 'app', {
     {
       family: 'lato',
       type: 'msdf',
-      png: '/fonts/Lato-Regular.msdf.png',
-      json: '/fonts/Lato-Regular.msdf.json',
+      png: 'fonts/Lato-Regular.msdf.png',
+      json: 'fonts/Lato-Regular.msdf.json',
     },
     {
       family: 'raleway',
       type: 'msdf',
-      png: '/fonts/Raleway-ExtraBold.msdf.png',
-      json: '/fonts/Raleway-ExtraBold.msdf.json',
+      png: 'fonts/Raleway-ExtraBold.msdf.png',
+      json: 'fonts/Raleway-ExtraBold.msdf.json',
     },
-    { family: 'opensans', type: 'web', file: '/fonts/OpenSans-Medium.ttf' },
+    { family: 'opensans', type: 'web', file: 'fonts/OpenSans-Medium.ttf' },
     {
       family: 'kalam',
       type: 'msdf',
-      png: '/fonts/Kalam-Regular.msdf.png',
-      json: '/fonts/Kalam-Regular.msdf.json',
+      png: 'fonts/Kalam-Regular.msdf.png',
+      json: 'fonts/Kalam-Regular.msdf.json',
     },
   ],
 })

--- a/src/pages/Intro.js
+++ b/src/pages/Intro.js
@@ -36,7 +36,7 @@ export default Blits.Component('Intro', {
     </Element>`,
   state() {
     return {
-      background: `${window.location.protocol}//${window.location.host}/assets/background.png`,
+      background: 'assets/background.png',
     }
   },
 })

--- a/vite.config.js
+++ b/vite.config.js
@@ -20,6 +20,7 @@ import blitsVitePlugins from '@lightningjs/blits/vite'
 
 export default defineConfig(({ command, mode, ssrBuild }) => {
   return {
+    base: '/', // Set to your base path if you are deploying to a subdirectory (example: /myApp/)
     plugins: [...blitsVitePlugins],
     resolve: {
       mainFields: ['browser', 'module', 'jsnext:main', 'jsnext'],


### PR DESCRIPTION
This PR resolves #4 by converting all absolute paths to relative ones and adding a `base` configuration in `vite.config.js` (default value is `/`). 

To deploy in a subdirectory like `/myApp/`, simply update the `base` value in `vite.config.js`. 