### PR TITLE
Replaces `function` with `easing` & uses Blits v0.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lightningjs/blits-example-app",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lightningjs/blits-example-app",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "Apache-2",
       "dependencies": {
         "@lightningjs/blits": "^0.8.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.7.0",
       "license": "Apache-2",
       "dependencies": {
-        "@lightningjs/blits": "^0.7.4"
+        "@lightningjs/blits": "^0.8.0"
       },
       "devDependencies": {
         "eslint": "^8.8.0",
@@ -844,9 +844,9 @@
       }
     },
     "node_modules/@lightningjs/blits": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/@lightningjs/blits/-/blits-0.7.4.tgz",
-      "integrity": "sha512-KQWCodZt7I5djdrFuDPGqFC0LoKgMDxBYAc7F1Fpzau5I+oVTPpL8/ZiPPhsRlooPpZ9fw47JtnkS+VL6T+o/g==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@lightningjs/blits/-/blits-0.8.0.tgz",
+      "integrity": "sha512-qXSvLekyImXX+y/7KPz2yZGyqUUe9BlZ8UtPXmqRjr1iYClgpGcyQyw/wIUmwXG7cBMZnekAaUCjAxWJ2UwQPg==",
       "dependencies": {
         "@lightningjs/renderer": "^0.7.4",
         "@lightningjs/vite-plugin-import-chunk-url": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
     "vite": "^4.0.4"
   },
   "dependencies": {
-    "@lightningjs/blits": "^0.7.4"
+    "@lightningjs/blits": "^0.8.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightningjs/blits-example-app",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Lightning 3 Blits Example App",
   "main": "index.js",
   "type": "module",

--- a/src/components/Background.js
+++ b/src/components/Background.js
@@ -21,10 +21,10 @@ export default Blits.Component('Background', {
   template: `
     <Element>
       <Element
-        :src="$bg1" w="1920" h="1080" color="{top: '#fff', bottom: '#000'}" :alpha.transition="{value: $alpha1, duration: 400, function: 'ease-in'}"
+        :src="$bg1" w="1920" h="1080" color="{top: '#fff', bottom: '#000'}" :alpha.transition="{value: $alpha1, duration: 400, easing: 'ease-in'}"
       />
       <Element
-        :src="$bg2" w="1920" h="1080" color="{top: '#fff', bottom: '#000'}" :alpha.transition="{value: $alpha2, duration: 400, function: 'ease-in'}"
+        :src="$bg2" w="1920" h="1080" color="{top: '#fff', bottom: '#000'}" :alpha.transition="{value: $alpha2, duration: 400, easing: 'ease-in'}"
       />
       <Element w="1920" h="1080" src="assets/gradient.png" color="#8866dd" alpha="0.8" />
     </Element>`,

--- a/src/components/Hero.js
+++ b/src/components/Hero.js
@@ -22,10 +22,10 @@ export default Blits.Component('Poster', {
     <Element w="1280" h="720" x="$x"
       :src="$item.background"
       color="{top: '#fff', bottom: '#000'}"
-      :scale.transition="{value: $scale, duration: 300, function: 'cubic-bezier(0.20, 1.00, 0.80, 1.00)'}"
+      :scale.transition="{value: $scale, duration: 300, easing: 'cubic-bezier(0.20, 1.00, 0.80, 1.00)'}"
       :effects="[$shader('radius', {radius: 8})]"
     >
-      <Element :alpha.transition="{value: $alpha, duration: 300, function: 'cubic-bezier(0.20, 1.00, 0.80, 1.00)'}" >
+      <Element :alpha.transition="{value: $alpha, duration: 300, easing: 'cubic-bezier(0.20, 1.00, 0.80, 1.00)'}" >
         <Element
           w="185" h="278" x="54" y="220"
           :src="$item.poster"

--- a/src/components/Letter.js
+++ b/src/components/Letter.js
@@ -20,11 +20,11 @@ import Blits from '@lightningjs/blits'
 export default Blits.Component('Letter', {
   template: `
     <Element>
-      <Element w="$w" :h.transition="{value: 410+$offset, duration: $duration, delay: $wait, function: $timingFunction}" color="#E6E6E6" />
-      <Element w="$w" h="280" :src="$image" :y.transition="{value: 400+$offset, duration: $duration, delay: $wait, function: $timingFunction}" />
+      <Element w="$w" :h.transition="{value: 410+$offset, duration: $duration, delay: $wait, easing: $timingFunction}" color="#E6E6E6" />
+      <Element w="$w" h="280" :src="$image" :y.transition="{value: 400+$offset, duration: $duration, delay: $wait, easing: $timingFunction}" />
       <Element w="$w" color="#E6E6E6"
-        :h.transition="{value: 500-$offset, duration: $duration, delay: $wait, function: $timingFunction}"
-        :y.transition="{value: 660+$offset, duration: $duration, delay: $wait, function: $timingFunction}"
+        :h.transition="{value: 500-$offset, duration: $duration, delay: $wait, easing: $timingFunction}"
+        :y.transition="{value: 660+$offset, duration: $duration, delay: $wait, easing: $timingFunction}"
       />
     </Element>`,
   props: ['w', 'letter', 'direction', 'delay'],
@@ -38,7 +38,7 @@ export default Blits.Component('Letter', {
       offset: this.direction === 'up' ? -680 : 680,
       duration: 1000,
       wait: 0,
-      timingFunction: 'cubic-bezier(1,-0.64,.39,1.44)',
+      timingeasing: 'cubic-bezier(1,-0.64,.39,1.44)',
     }
   },
   hooks: {

--- a/src/components/Poster.js
+++ b/src/components/Poster.js
@@ -22,7 +22,7 @@ export default Blits.Component('Poster', {
     <Element
       w="185" h="278" x="$x"
       :src="$item.poster"
-      :scale.transition="{value: $scale, duration: 200, function: 'cubic-bezier(0.20, 1.00, 0.80, 1.00)'}"
+      :scale.transition="{value: $scale, duration: 200, easing: 'cubic-bezier(0.20, 1.00, 0.80, 1.00)'}"
       :effects="[$shader('radius', {radius: 8})]"
     />`,
   props: ['src', 'index', 'item', 'width'],

--- a/src/components/PosterTitle.js
+++ b/src/components/PosterTitle.js
@@ -21,13 +21,13 @@ export default Blits.Component('PosterTitle', {
   template: `
     <Element w="185" h="278" x="$x"
       :src="$item.poster"
-      :scale.transition="{value: $scale, duration: 200, function: 'cubic-bezier(0.20, 1.00, 0.80, 1.00)'}"
+      :scale.transition="{value: $scale, duration: 200, easing: 'cubic-bezier(0.20, 1.00, 0.80, 1.00)'}"
       :effects="[$shader('radius', {radius: 8})]"
     >
       <Element
       x="10"
-      :y.transition="{value: $y, duration: 300, function: 'cubic-bezier(0.20, 1.00, 0.80, 1.00)'}"
-      :alpha.transition="{value: $alpha, duration: 300, function: 'cubic-bezier(0.20, 1.00, 0.80, 1.00)'}" >
+      :y.transition="{value: $y, duration: 300, easing: 'cubic-bezier(0.20, 1.00, 0.80, 1.00)'}"
+      :alpha.transition="{value: $alpha, duration: 300, easing: 'cubic-bezier(0.20, 1.00, 0.80, 1.00)'}" >
         <Text :content="$item.title" font="raleway" size="22" wordwrap="185" maxlines="2" lineheight="28" />
       </Element>
     </Element>`,

--- a/src/components/TmdbRow.js
+++ b/src/components/TmdbRow.js
@@ -29,7 +29,7 @@ export default Blits.Component('TmdbRow', {
   },
   template: `
     <Element>
-      <Element :x.transition="{value: $x, duration: 300, function: 'ease-in-out'}" y="80">
+      <Element :x.transition="{value: $x, duration: 300, easing: 'ease-in-out'}" y="80">
         <Component is="$type" :for="(item, index) in $items" index="$index" item="$item" ref="poster" width="$width" :key="$item.identifier" />
       </Element>
     </Element>

--- a/src/pages/Alpha.js
+++ b/src/pages/Alpha.js
@@ -36,7 +36,7 @@ export default Blits.Component('Alpha', {
       <Element w="200" h="200" x="100" y="540" color="#fff" :alpha="$alpha" />
 
       <!-- reactive alpha value (with transition) -->
-      <Element w="200" h="200" x="100" y="760" color="#fff" :alpha.transition="{value: $alpha, duration: 1000, function: 'ease-in-out-circ'}" />
+      <Element w="200" h="200" x="100" y="760" color="#fff" :alpha.transition="{value: $alpha, duration: 1000, easing: 'ease-in-out-circ'}" />
 
       <Element w="428" h="234" x="1200" y="100" :src="$image" alpha="1" />
       <Element w="428" h="234" x="1300" :y="100 + 234 - 40" :src="$image" alpha=".4" />

--- a/src/pages/Scaling.js
+++ b/src/pages/Scaling.js
@@ -29,7 +29,7 @@ export default Blits.Component('Scaling', {
       <Element x="100" y="400" w="100" h="100" color="#b45309" scale="$scale" />
 
       <!-- reactive scaling (with transition) -->
-      <Element x="900" y="400" w="100" h="100" :src="$balloon" :scale.transition="{value: $scale, function: 'ease-in-out'}" />
+      <Element x="900" y="400" w="100" h="100" :src="$balloon" :scale.transition="{value: $scale, easing: 'ease-in-out'}" />
 
       <!-- scaling with a nested element -->
       <Element x="300" y="600" w="100" h="100" color="#059669" :scale="$scale2">

--- a/src/pages/Tmdb.js
+++ b/src/pages/Tmdb.js
@@ -37,7 +37,7 @@ export default Blits.Component('TMdb', {
           <Text :content="$title" font="raleway" size="80" x="140" y="300" wordwrap="1000" @loaded="$positionText" maxlines="1" />
           <Text :content="$overview" wordwrap="880" x="140" y="430" lineheight="40" maxlines="3" />
         </Element>
-        <Element :y.transition="{value: $y, duration: 300, function: 'cubic-bezier(0.20, 1.00, 0.80, 1.00)'}">
+        <Element :y.transition="{value: $y, duration: 300, easing: 'cubic-bezier(0.20, 1.00, 0.80, 1.00)'}">
           <TmdbRow :for="(row, index) in $rows" :key="$row.title" title="$row.title" :items="$row.items" :type="$row.type" :width="$row.width" y="$row.y" ref="row" />
         </Element>
       </Element>

--- a/src/pages/Transitions.js
+++ b/src/pages/Transitions.js
@@ -36,13 +36,13 @@ export default Blits.Component('Transitions', {
         :y.transition="{value: $y, duration: 500, delay: 1000, start: $start, end: $finished}" color="#7c3aed"
       />
       <!-- transition with built-in easing function -->
-      <Element w="200" h="200" x="1050" :y.transition="{value: $y, function: 'ease-in-out', end: $finished}" color="#6d28d9" />
+      <Element w="200" h="200" x="1050" :y.transition="{value: $y, easing: 'ease-in-out', end: $finished}" color="#6d28d9" />
       <!-- transition with custom duration and a built-in easing function -->
       <Element
         w="200" h="200" x="1300"
-        :y.transition="{value: $y, duration: 3000, function: 'ease-in-out-back', end: $finished}" color="#5b21b6" />
+        :y.transition="{value: $y, duration: 3000, easing: 'ease-in-out-back', end: $finished}" color="#5b21b6" />
       <!-- transition with custom duration and a custum bezier function -->
-      <Element w="200" h="200" x="1550" :y.transition="{value: $y, duration: 800, function: 'cubic-bezier(1,-0.64,.39,1.44)'}" color="#4c1d95" />
+      <Element w="200" h="200" x="1550" :y.transition="{value: $y, duration: 800, easing: 'cubic-bezier(1,-0.64,.39,1.44)'}" color="#4c1d95" />
     </Element>`,
   state() {
     return {


### PR DESCRIPTION
- The property name for a transition easing function is changed from `function` to `easing` with Blits v0.8.0. So this PR replaces all `function` property names to `easing`.
- Updates `package.json` so now it depends on Blits v0.8.0 instead of 0.7.4

_Note: I haven't changed the app version in the package.json, we should modify it maybe before merging the PR_