### PR TITLE
fixes empty array issue (type definitions) for state variables 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,7 @@
     "editor.codeActionsOnSave": {
       "source.fixAll.eslint": "explicit"
     },
-    "js/ts.implicitProjectConfig.checkJs": true
+    "js/ts.implicitProjectConfig.checkJs": true,
+    "js/ts.implicitProjectConfig.strictNullChecks": false,
+    "blits.format.printWidth": 120
   }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,5 @@
       "source.fixAll.eslint": "explicit"
     },
     "js/ts.implicitProjectConfig.checkJs": true,
-    "js/ts.implicitProjectConfig.strictNullChecks": false,
-    "blits.format.printWidth": 120
+    "js/ts.implicitProjectConfig.strictNullChecks": false
   }


### PR DESCRIPTION
Related to [the updated type definitions for Blits](https://github.com/lightning-js/blits/pull/88), [based on @michielvandergeest's suggestion] disabling `strictNullChecks` fixes the issue where empty arrays getting `never[]` type incorrectly. 

I tested the change and now pushing items to an empty array defined in `state()` does not cause vscode to display an error about it. Now empty arrays get `any[]` type instead of `never[]`.