### PR TITLE
Update .eslintrc.cjs to include endOfLine configuration.

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -44,6 +44,7 @@ module.exports = {
         tabWidth: 2,
         semi: false,
         printWidth: 100,
+        endOfLine: 'auto',
       },
     ],
   },


### PR DESCRIPTION
 This will prevent the whole IDE going red when opened on windows.

for example without this:
![image](https://github.com/user-attachments/assets/b82a09f9-c1a7-4215-851a-3f72378bae00)
