### PR TITLE
Blits version update to 1.38.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightningjs/blits-example-app",
-  "version": "1.15.1",
+  "version": "1.16.1",
   "description": "Lightning 3 Blits Example App",
   "main": "index.js",
   "type": "module",
@@ -48,6 +48,6 @@
   },
   "dependencies": {
     "@firebolt-js/sdk": "^1.4.1",
-    "@lightningjs/blits": "^1.35.1"
+    "@lightningjs/blits": "^1.38.2"
   }
 }

--- a/src/components/MemoryCard.js
+++ b/src/components/MemoryCard.js
@@ -77,7 +77,7 @@ export default Blits.Component('MemoryCard', {
         }
       })
     },
-    focus(e) {
+    focus() {
       this.scale = 1.08
       const message = 'Card ' + (this.index + 1) + (this.disabled ? ' (disabled)' : '')
       this.announcement = this.$announcer.speak(message)

--- a/src/pages/Focus.js
+++ b/src/pages/Focus.js
@@ -137,7 +137,7 @@ export default Blits.Component('Focus', {
     left() {
       this.index = Math.max(1, this.index - 1)
     },
-    right(e) {
+    right() {
       this.index = Math.min(3, this.index + 1)
       // this.parent.$focus(e)
     },

--- a/src/pages/Portal.js
+++ b/src/pages/Portal.js
@@ -253,9 +253,9 @@ export default Blits.Component('Portal', {
     ready() {
       this.logoOffset = 0
     },
-    focus(){
+    focus() {
       this.$trigger('rowFocused')
-    }
+    },
   },
   watch: {
     rowFocused(v) {


### PR DESCRIPTION

Updated @lightningjs/blits dependency from 1.35.1 → 1.38.2.
Bumped example app version from 1.15.1 → 1.16.1.
Removed linting errors for cleaner code consistency.