### PR TITLE
Blits example-app master version update to 1.38.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightningjs/blits-example-app",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "description": "Lightning 3 Blits Example App",
   "main": "index.js",
   "type": "module",
@@ -48,6 +48,6 @@
   },
   "dependencies": {
     "@firebolt-js/sdk": "^1.4.1",
-    "@lightningjs/blits": "^1.36.0"
+    "@lightningjs/blits": "^1.38.2"
   }
 }


### PR DESCRIPTION

Updated @lightningjs/blits dependency from 1.36.0 → 1.38.2.
Bumped example app version from 1.16.0 → 1.16.1.